### PR TITLE
downgrade alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine AS base
+FROM golang:alpine3.13 AS base
 
 ARG PROTO_VERSION=3.17.3
 ARG PROTO_ZIP_FILE=protoc-${PROTO_VERSION}-linux-x86_64.zip
@@ -17,7 +17,7 @@ RUN go mod init tmpmod && go mod tidy && go install \
 RUN wget $PROTO_BIN_URL && unzip $PROTO_ZIP_FILE -d protoc && mv protoc/include /usr/local
 RUN git clone $GOOGLE_APIS_URL && mv googleapis/google/* /usr/local/include/google/
 
-FROM golang:alpine
+FROM golang:alpine3.13
 COPY --from=base /go/bin /go/bin
 COPY --from=base /usr/local/include /usr/local/include
 RUN apk update && apk upgrade && apk add make git protobuf


### PR DESCRIPTION
use alpine3.13 instead of latest as 3.14 has problem with docker versions that are not the latest one